### PR TITLE
Add Chrome Extension download button

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -192,6 +192,55 @@ textarea:focus { border-color: #2cbc63; outline: none; }
 .btn:hover { color: #ffffff; opacity: 0.7; }
 .btn:focus { box-shadow: none; color: #ffffff; }
 
+/* Chrome Extension Button */
+.chrome-extension-download {
+    text-align: center;
+    margin: 80px 0;
+}
+
+.btn-chrome-extension {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 15px 25px;
+    background: linear-gradient(135deg, #4285f4 0%, #f44242 30%, #fbbc05 60%, #34a853 100%);
+    color: #fff;
+    text-decoration: none;
+    border-radius: 12px;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 15px rgba(66, 133, 244, 0.3);
+    min-width: 200px;
+    border: none;
+}
+
+.btn-chrome-extension:hover {
+    color: #fff;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(66, 133, 244, 0.4);
+    text-decoration: none;
+}
+
+.btn-chrome-extension i {
+    font-size: 24px;
+    margin-bottom: 5px;
+    color: #000;
+}
+
+.btn-chrome-extension span {
+    font-size: 16px;
+    font-weight: 600;
+    margin-top: 10px;
+    color: #fff;
+}
+
+.btn-chrome-extension small {
+    font-size: 12px;
+    opacity: 0.9;
+    font-weight: 400;
+    color: #000;
+}
+
 .popup-background { background-color: rgba(0, 0, 0, 0.8); position: fixed; top: 0; left: 0; right: 0; bottom: 0; z-index: 999; display: none; }
 
 .popup { position: fixed; top: 0; left: -280px; bottom: 0; width: 280px; background-color: #ffffff; box-shadow: -2px 0 4px 0 rgba(0, 0, 0, 0.2); z-index: 1000; overflow: auto; opacity: 0; visibility: hidden; transition: all 0.3s; }

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -90,6 +90,18 @@
                                     class="las la-search la-24-black"></i></button>
                         </div>
                     </form><!-- .site-banner__search -->
+
+                    <!-- Chrome Extension Download Button -->
+                    @if(env('CHROME_EXTENSION_URL'))
+                        <div class="chrome-extension-download mt-8">
+                            <a href="{{ env('CHROME_EXTENSION_URL') }}" target="_blank" class="btn btn-chrome-extension">
+                                <i class="lab la-chrome"></i>
+                                <span>Download for Chrome</span>
+                                <small>Get the extension for quick email checking</small>
+                            </a>
+                        </div>
+                    @endif
+
                     @if($error)
                         <p class="site-banner__meta">
                             <span style="color: darkred">{{ $error }}</span>


### PR DESCRIPTION
Added Chrome extension download button to the landing page with Google Chrome styling and smooth hover effects. The button URL is configurable via CHROME_EXTENSION_URL in the .env file and only shows when the URL is set.